### PR TITLE
return nil when GroupActivities AsyncSequences return nil

### DIFF
--- a/Sources/SharePlayMock/GroupSessionMessengerMock.swift
+++ b/Sources/SharePlayMock/GroupSessionMessengerMock.swift
@@ -146,8 +146,11 @@ extension GroupSessionMessengerMock {
             
             public func next() async -> Messages<Message>.Element? {
                 if var iterator = self.iterator {
-                    let element = await iterator.next()!
-                    return (element.0, MockMessageContext(source: ParticipantMock.pack(element.1.source)))
+                    if let element = await iterator.next() {
+                        return (element.0, MockMessageContext(source: ParticipantMock.pack(element.1.source)))
+                    } else {
+                        return nil
+                    }
                 }
                 else {
                     while elements.isEmpty {

--- a/Sources/SharePlayMock/GroupSessionMock.swift
+++ b/Sources/SharePlayMock/GroupSessionMock.swift
@@ -153,8 +153,11 @@ extension GroupSessionMock {
             
             public func next() async -> GroupSessionMock<M>? {
                 if var iterator = self.iterator {
-                    let session = await iterator.next()
-                    return GroupSessionMock(session: session!)
+                    if let session = await iterator.next() {
+                        return GroupSessionMock(session: session)
+                    } else {
+                        return nil
+                    }
                 } else {
                     if let mock = SharePlayMockManager.useMock(),
                         let webSocket = mock.webSocket {


### PR DESCRIPTION
## Description
This change fixed the crash when we call `session.end()`

## Test Plan
Tested on a real SharePlay app and noticed the crash is gone 